### PR TITLE
Report outputs on non-zero exit code situation

### DIFF
--- a/function.go
+++ b/function.go
@@ -71,7 +71,9 @@ func (fn *Function) Run() (string, string, error) {
 		return "", "", fmt.Errorf("Failed to start command: %s", err)
 	}
 
-	stdin.Write(fn.Payload)
+	if _, err := stdin.Write(fn.Payload); err != nil {
+		return "", "", fmt.Errorf("failed to write to stdin: %w", err)
+	}
 	stdin.Close()
 
 	wg := &sync.WaitGroup{}

--- a/function.go
+++ b/function.go
@@ -49,17 +49,17 @@ func (fn *Function) Run() (string, string, error) {
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to open stdout pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stdout pipe: %s", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to open stderr pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stderr pipe: %s", err)
 	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to open stdin pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stdin pipe: %s", err)
 	}
 
 	var stdout1, stderr1 bytes.Buffer
@@ -68,7 +68,7 @@ func (fn *Function) Run() (string, string, error) {
 
 	err = cmd.Start()
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to start command: %s", err)
+		return "", "", fmt.Errorf("failed to start command: %s", err)
 	}
 
 	if _, err := stdin.Write(fn.Payload); err != nil {
@@ -88,7 +88,7 @@ func (fn *Function) Run() (string, string, error) {
 			fmt.Fprintln(fn.Stdout, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			fmt.Fprintln(fn.Stderr, "Scan error (stdout):", err)
+			fmt.Fprintln(fn.Stderr, "scan error (stdout):", err)
 		}
 		wg.Done()
 	}()
@@ -103,7 +103,7 @@ func (fn *Function) Run() (string, string, error) {
 			fmt.Fprintln(fn.Stderr, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			fmt.Fprintln(fn.Stderr, "Scan error (stderr):", err)
+			fmt.Fprintln(fn.Stderr, "scan error (stderr):", err)
 		}
 		wg.Done()
 	}()

--- a/function.go
+++ b/function.go
@@ -49,17 +49,17 @@ func (fn *Function) Run() (string, string, error) {
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open stdout pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stdout pipe: %w", err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open stderr pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stderr pipe: %w", err)
 	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open stdin pipe: %s", err)
+		return "", "", fmt.Errorf("failed to open stdin pipe: %w", err)
 	}
 
 	var stdout1, stderr1 bytes.Buffer
@@ -68,7 +68,7 @@ func (fn *Function) Run() (string, string, error) {
 
 	err = cmd.Start()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to start command: %s", err)
+		return "", "", fmt.Errorf("failed to start command: %w", err)
 	}
 
 	if _, err := stdin.Write(fn.Payload); err != nil {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,9 @@ func HandleEvent(ctx context.Context, payload json.RawMessage) (string, error) {
 			(notifyCond == "exitcode" && err != nil)) {
 
 		af := buildSlackAttachmentFields(os.Getenv("AWS_LAMBDA_FUNCTION_NAME"), lc.AwsRequestID, stdout, stderr, err)
-		postSlack(slackWebhookURL, af)
+		if err := postSlack(slackWebhookURL, af); err != nil {
+			return "Failed", fmt.Errorf("Lapper failed to post a message to slack: %w", err)
+		}
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -45,10 +45,10 @@ func HandleEvent(ctx context.Context, payload json.RawMessage) (string, error) {
 	}
 
 	if err != nil {
-		return fmt.Sprintf("Failed"), err
+		return "Failed", err
 	}
 
-	return fmt.Sprintf("Succeeded"), nil
+	return "Succeeded", nil
 }
 
 func getEnv(key, fallback string) string {


### PR DESCRIPTION
Currently, Lapper is unable to report outputs when a non-zero exit code occurs. The underlying commands should exit with a non-zero code when they encounter errors, so Lapper should handle these situations and report the outputs accordingly.

Tested locally with shell example.